### PR TITLE
allow to extract ranges instead of sub strings

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use srx::{Rules, SRX};
 
 fn split<'a>(string: &'a str, rules: &Rules) -> Vec<&'a str> {
-    rules.split(string)
+    rules.split(string).collect::<Vec<_>>()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -15,12 +15,12 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("split string", |b| {
         b.iter(|| {
-            split(
+            let _ = split(
                 black_box(
                     "The U.K. Prime Minister, Mr. Blair, was seen out with his family today.",
                 ),
                 &rules,
-            )
+            );
         })
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl Rules {
         segments
     }
 
-    /// Split text into sentences.
+    /// Split text into segments.
     pub fn split<'a, 'b>(&self, text: &'a str) -> impl Iterator<Item = &'a str> + 'b
     where
         'a: 'b,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ impl Rules {
 
         // Iterate over characters, we don't want no half characters in the output ranges
         for (byte_pos, _c) in text.char_indices() {
-            if let Some(Some(true)) = masked_bytes.get(byte_pos) {
+            if let Some(true) = masked_bytes[byte_pos] {
                 segments.push(prev_byte_pos..byte_pos);
                 prev_byte_pos = byte_pos;
             }


### PR DESCRIPTION
This allows to create abstractions based on byte ranges (which are guaranteed to be at char boundaries).

`cargo-spellcheck` will move to this for segmentation rather sooner than later.