### PR TITLE
Added a main.rs for a fair comparison with loomchild/segment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/srx"
 
 [dependencies]
 regex = "1"
+clap = { version = "3.1.18", features = ["derive"] }
 
 # workaround to use a 'serde' feature which also enables 'serde_regex'
 # see https://github.com/RustCrypto/RSA/pull/41/files

--- a/src/from_xml.rs
+++ b/src/from_xml.rs
@@ -182,7 +182,7 @@ mod schema {
     pub struct Header {
         pub segmentsubflows: Option<String>,
         pub cascade: String,
-        #[serde(rename = "formathandle")]
+        #[serde(rename = "formathandle", default)]
         pub handles: Vec<FormatHandle>,
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,61 @@
+use std::fs::{File, read_to_string};
+use std::io::prelude::*;
+use std::io::LineWriter;
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::str::FromStr;
+use srx::SRX;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Name of the person to greet
+    #[clap(short, long, default_value="en")]
+    language: String,
+    #[clap(short, long)]
+    input: String,
+    #[clap(short, long)]
+    output: String,
+    #[clap(short, long)]
+    srxfile: String,
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+
+    // Prepare output file to be written segment by segment
+    let file = File::create(args.output)?;
+    let mut file = LineWriter::new(file);
+    // Load SRX rules from file
+    let rules =
+        SRX::from_str(&read_to_string(args.srxfile).expect("rules file exists"))
+            .expect("srx rule file is valid")
+            .language_rules(args.language);
+
+    // Read each input file line (it could be a whole document)
+    if let Ok(lines) = read_lines(args.input) {
+        // Consumes the iterator, returns an (Optional) String
+        for line in lines {
+            if let Ok(doc) = line {
+                // Split the content using the SRX segmenter and write each segment to the output
+                for splittedline in rules.split(&doc).collect::<Vec<_>>(){
+                    file.write(splittedline.as_bytes())?;
+                    file.write(b"\n")?;
+                }
+            }
+        }
+    }
+
+    file.flush()?;
+    Ok(())
+
+}
+
+// The output is wrapped in a Result to allow matching on errors
+// Returns an Iterator to the Reader of the lines of the file.
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+    where P: AsRef<Path>, {
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// Name of the person to greet
+    /// ISO-639-1, 2 char language code
     #[clap(short, long, default_value="en")]
     language: String,
     #[clap(short, long)]
@@ -19,6 +19,8 @@ struct Args {
     output: String,
     #[clap(short, long)]
     srxfile: String,
+    #[clap(short, long)]
+    verbose: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -28,10 +30,16 @@ fn main() -> io::Result<()> {
     let file = File::create(args.output)?;
     let mut file = LineWriter::new(file);
     // Load SRX rules from file
-    let rules =
+    let srx =
         SRX::from_str(&read_to_string(args.srxfile).expect("rules file exists"))
-            .expect("srx rule file is valid")
-            .language_rules(args.language);
+            .expect("srx rule file is valid");
+    if args.verbose {
+        println!("SRX rules errors while parsing with regex, by language: {:?}", srx.errors());
+    }
+    let rules = srx.language_rules(args.language);
+    if args.verbose {
+        println!("Using these rules for the selected language: {:?}", rules);
+    }
 
     // Read each input file line (it could be a whole document)
     if let Ok(lines) = read_lines(args.input) {


### PR DESCRIPTION
The original LanguageTool sentence splitter/segmenter/sentencizer, which uses SRX, is hosted here: https://github.com/loomchild/segment

As part of our work, we performed some changes on it on https://github.com/mbanon/segment and tried to compare its performance with Moses `split-sentences.perl` and NLTK sentence splitters.

To expand this comparison, I created a `main.rs` for this project that mimics the interface that loomchild's segment uses: https://github.com/mbanon/segment/blob/master/README.md#running

Note: build this Crate by using all features to be able to use it: `cargo build --all-features --release`