### PR TITLE
Optional <formathandle> field in xml

### DIFF
--- a/src/from_xml.rs
+++ b/src/from_xml.rs
@@ -182,7 +182,7 @@ mod schema {
     pub struct Header {
         pub segmentsubflows: Option<String>,
         pub cascade: String,
-        #[serde(rename = "formathandle")]
+        #[serde(rename = "formathandle", default)]
         pub handles: Vec<FormatHandle>,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,6 @@ mod tests {
                 .expect("segment file is valid");
 
         assert!(!srx.errors().is_empty());
-        assert_eq!(srx.errors().values().flatten().count(), 51);
+        assert_eq!(srx.errors().values().flatten().count(), 49);
     }
 }


### PR DESCRIPTION
Accoriding to the [specification](https://www.ttt.org/oscarStandards/srx/srx20.html#SectionStructure), the header can contain zero `<formathandle>` elements, so I made it optional. This fixes the loading of [some SRX files](https://github.com/mbanon/segment/blob/master/srx/PTDR.srx) that do not contain that element and therefore were crashing with:
```
thread 'main' panicked at 'srx rule file is valid: XMLError(Custom { field: "missing field `formathandle`" })', 
```